### PR TITLE
remove numeric requirements from `ptrace`, `ptranspose` and `reshuffle`

### DIFF
--- a/src/ptrace.jl
+++ b/src/ptrace.jl
@@ -8,7 +8,7 @@ $(SIGNATURES)
 
 Return [partial trace](https://en.wikipedia.org/wiki/Partial_trace) of matrix `ρ` over the subsystems determined by `isystems`.
 """
-function ptrace(ρ::AbstractMatrix{<:Number}, idims::Vector{Int}, isystems::Vector{Int})
+function ptrace(ρ::AbstractMatrix, idims::Vector{Int}, isystems::Vector{Int})
     dims = reverse(idims)
     systems = length(idims) .- isystems .+ 1
 
@@ -38,7 +38,7 @@ $(SIGNATURES)
 - `idims`: dimensins of subsystems.
 - `sys`: traced subsystem.
 """
-ptrace(ρ::AbstractMatrix{<:Number}, idims::Vector{Int}, sys::Int) = ptrace(ρ, idims, [sys])
+ptrace(ρ::AbstractMatrix, idims::Vector{Int}, sys::Int) = ptrace(ρ, idims, [sys])
 
 """
 $(SIGNATURES)
@@ -46,7 +46,7 @@ $(SIGNATURES)
 - `idims`: dimensins of subsystems - only bipartite states accepted.
 - `sys`: traced subsystem.
 """
-function ptrace(ψ::AbstractVector{<:Number}, idims::Vector{Int}, sys::Int)
+function ptrace(ψ::AbstractVector, idims::Vector{Int}, sys::Int)
     # TODO : Allow mutlipartite systems
     length(idims) == 2 ? () : throw(ArgumentError("idims has to be of length 2"))
     _, cols = idims

--- a/src/ptranspose.jl
+++ b/src/ptranspose.jl
@@ -7,7 +7,7 @@ $(SIGNATURES)
 
 Return [partial transposition](http://en.wikipedia.org/wiki/Peres-Horodecki_criterion) of matrix `ρ` over the subsystems determined by `isystems`.
 """
-function ptranspose(ρ::AbstractMatrix{<:Number}, idims::Vector{Int}, isystems::Vector{Int})
+function ptranspose(ρ::AbstractMatrix, idims::Vector{Int}, isystems::Vector{Int})
     dims = reverse(idims)
     systems = length(idims) .- isystems .+ 1
 
@@ -39,7 +39,7 @@ $(SIGNATURES)
 - `idims`: dimensins of subsystems.
 - `sys`: transposed subsystem.
 """
-ptranspose(ρ::AbstractMatrix{<:Number}, idims::Vector{Int}, sys::Int) = ptranspose(ρ, idims, [sys])
+ptranspose(ρ::AbstractMatrix, idims::Vector{Int}, sys::Int) = ptranspose(ρ, idims, [sys])
 
 function _ptranspose(ρ::AbstractMatrix{<:Number}, idims::Vector{Int}, isystems::Vector{Int})
     ns = length(idims)

--- a/src/reshuffle.jl
+++ b/src/reshuffle.jl
@@ -5,7 +5,7 @@ export reshuffle
 #   Given multiindexed matrix M_{(m,μ),(n,ν)} it returns
 #   matrix M_{(m,n),(μ,ν)}.
 # """
-function reshuffle(ρ::AbstractMatrix{<:Number}, dims::Matrix{Int})
+function reshuffle(ρ::AbstractMatrix, dims::Matrix{Int})
   m, n, μ, ν  = dims
   tensor = reshape(ρ, μ, m, ν, n)
   perm = [4, 2, 3, 1]
@@ -20,7 +20,7 @@ end
   Given multiindexed matrix \$M_{(m,μ),(n,ν)}\$ it returns
   matrix \$M_{(m,n),(μ,ν)}\$.
 """
-function reshuffle(ρ::AbstractMatrix{<:Number})
+function reshuffle(ρ::AbstractMatrix)
     (r, c) = size(ρ)
     sqrtr = isqrt(r)
     sqrtc = isqrt(c)


### PR DESCRIPTION
This allows to use general types in matrices passed to these functions, for instance from `JuMP`